### PR TITLE
Fix gene.filter MT gene recognization

### DIFF
--- a/R/fs.R
+++ b/R/fs.R
@@ -344,7 +344,7 @@ gene.filter = function(ref,st,var_thresh = 0.025,exp_thresh = 0.003){
   MIN.OBS = exp_thresh*nspots
   bulk.vec = rowSums(st)
   gene.list = rownames(ref)
-  if(length(grep("[Mm][Tt]-",gene.list))>0)gene.list = gene.list[-grep("mt-", gene.list)]
+  if(length(grep("[Mm][Tt]-",gene.list))>0)gene.list = gene.list[-grep("mt-|MT-", gene.list)]
   gene.list = intersect(gene.list, names(bulk.vec))
   gene.list = gene.list[bulk.vec[gene.list] >= MIN.OBS]
   vars=apply(ref[gene.list,],1,var)


### PR DESCRIPTION
Using grep("mt-") will match only those gene symbols that start with the lowercase "mt". To ensure comprehensive filtering, it's necessary to include "MT" in the pattern; otherwise, no genes will remain post-filtering. 